### PR TITLE
Chore/revise minor legacy config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ascender
 
-![stable](https://img.shields.io/badge/stable-v0.2.0-blue)
+![stable](https://img.shields.io/badge/stable-v0.3.0-blue)
 ![python versions](https://img.shields.io/badge/python-3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11%20%7C%203.12-blue)
 [![tests](https://github.com/cvpaperchallenge/Ascender/actions/workflows/lint-and-test.yaml/badge.svg)](https://github.com/cvpaperchallenge/Ascender/actions/workflows/lint-and-test.yaml)
 [![MIT License](https://img.shields.io/github/license/cvpaperchallenge/Ascender?color=green)](LICENSE)

--- a/environments/ci/docker-compose.yaml
+++ b/environments/ci/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
       args:
         - BASE_IMAGE=ubuntu:20.04
         - PYTHON_VERSION=3.12
-        - RUN_POETRY_INSTALL_AT_BUILD_TIME=true
+        - RUN_UV_SYNC_AT_BUILD_TIME=true
         - PROJECT_NAME=${PROJECT_NAME_ENV}
       context: ../../
       dockerfile: environments/Dockerfile

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "ascender"
 version = "0.3.0"
 description = "Add your description here"
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.8"
 dependencies = []
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ package = false
 python-preference = "only-system"
 
 [tool.mypy]
-python_version = 3.8
+python_version = 3.12
 # following setting is same as pysen
 # https://github.com/pfnet/pysen/blob/main/setup.cfg#L12
 check_untyped_defs = true
@@ -37,7 +37,7 @@ warn_unused_ignores = true
 
 [tool.ruff]
 line-length = 88
-target-version = "py38"
+target-version = "py312"
 
 [tool.ruff.lint]
 select = ["E", "F", "B", "I", "N", "D", "PT"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ascender"
-version = "0.1.0"
+version = "0.3.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "ascender"
-version = "0.1.0"
+version = "0.3.0"
 source = { virtual = "." }
 
 [package.metadata]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-requires-python = ">=3.12"
+requires-python = ">=3.8"
 
 [[package]]
 name = "ascender"


### PR DESCRIPTION
## Issue URL

close: #3 

## Change overview

- Updated the version display of Ascender from **0.1.0** to **0.3.0**.
- Changed the Python version requirement in `pyproject.toml` from `>=3.12` to **`>=3.8`**. The `uv.lock` file has been updated accordingly.
- Updated the target Python version for `mypy` and `ruff` from **3.8** to **3.12**.
- Changed the build argument in `ci/docker-compose.yaml` from `RUN_POETRY_INSTALL_AT_BUILD_TIME` to **`RUN_UV_SYNC_AT_BUILD_TIME`**.

## How to test

Please follow the instruction written in `README.md`. 

## Note for reviewers

NA